### PR TITLE
Updating Sauce Labs Docs Links

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Selenium Scripts in Ruby used in the Sauce Labs DOCS wiki
 
 These are example scripts of how to run Ruby-based Selenium tests with Sauce Labs. For more information on their contents, see these topics in the Sauce Labs wiki:
 
-https://wiki.saucelabs.com/display/DOCS/Instant+Ruby+Tests+with+Sauce+Labs
+https://wiki.saucelabs.com/display/DOCS/Instant+Selenium+Ruby+Tests
 https://wiki.saucelabs.com/display/DOCS/Ruby+Test+Setup+Example
 
 This code is provided on an "AS-IS” basis without warranty of any kind, either express or implied, including without limitation any implied warranties of condition, uninterrupted use, merchantability, fitness for a particular purpose, or non-infringement. Your tests and testing environments may require you to modify this code. Issues regarding this code should be submitted through GitHub. For questions regarding Sauce Labs integration, please see the Sauce Labs documentation at https://wiki.saucelabs.com/. This framework is not maintained by Sauce Labs Support.


### PR DESCRIPTION
https://wiki.saucelabs.com/display/DOCS/Instant+Ruby+Tests+with+Sauce+Labs no longer is a valid link to the Docs Wiki, so updating the README with the new, correct link
